### PR TITLE
Fix API helper and cleanup tryon page

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,9 +1,9 @@
-export async function generateTryon(imageUrl, params) {
+export async function generateTryon(imageUrl, prompt) {
   const res = await fetch('/api/tryon', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ imageUrl, params }),
+    body: JSON.stringify({ imageUrl, prompt }),
   });
   const data = await res.json();
-  return data.tryonImage;
+  return data.output;
 }

--- a/pages/tryon.js
+++ b/pages/tryon.js
@@ -6,11 +6,6 @@ import TryOnCustomizer from '@/components/TryOnCustomizer';
 import Spinner from '@/components/Spinner';
 import Toast from '@/components/Toast';
 import Button from '@/components/Button';
-const res = await fetch('/api/tryon', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify({ imageUrl, prompt }), // ← make sure both are provided
-});
 
 function generateDynamicPrompt({ product, height, skinTone, background, bodyType, style, angle }) {
   return `


### PR DESCRIPTION
## Summary
- correct `generateTryon` helper to accept a prompt and read the proper API response
- remove stray fetch call at the top of `pages/tryon.js`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b2a96232c833180aa0a0d8a377f52